### PR TITLE
0.0.6 - initial FFI has been integrated and used by Swift

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mazer"
-version = "0.0.5"
+version = "0.0.6"
 authors = ["Jeffrey Isabella <jeff.isabella@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
We will begin a major refactor with FFI logic to instead use an opaque pointer to Grid instead of converting to FFICells
