### PR TITLE
0.0.9 - Delta (triangular celled) maze navigation fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mazer"
-version = "0.0.8"
+version = "0.0.9"
 authors = ["Jeffrey Isabella <jeff.isabella@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/src/algorithms/aldous_broder.rs
+++ b/src/algorithms/aldous_broder.rs
@@ -5,6 +5,7 @@ use crate::error::Error;
 
 pub struct AldousBroder;
 
+// TODO: This current implementation of Aldous Broder leads to unperfect Delta mazes; is this to be expected?
 impl MazeGeneration for AldousBroder {
     fn generate(&self, grid: &mut Grid) -> Result<(), Error> {
         // Step 1: Initialize visited tracking using Vec<Vec<bool>>
@@ -104,6 +105,18 @@ mod tests {
     #[test]
     fn generate_12_x_6_delta_maze() {
         match Grid::new(MazeType::Delta, 12, 6, Coordinates { x: 0, y: 0 }, Coordinates { x: 11, y: 5 }) {
+            Ok(mut grid) => {
+                assert!(!grid.is_perfect_maze().unwrap());
+                AldousBroder.generate(&mut grid).expect("AldousBroder maze generation failed");
+                assert!(grid.is_perfect_maze().unwrap());
+            }
+            Err(e) => panic!("Unexpected error running test: {:?}", e),
+        }
+    }
+    
+    #[test]
+    fn generate_12_x_12_delta_maze() {
+        match Grid::new(MazeType::Delta, 12, 12, Coordinates { x: 0, y: 0 }, Coordinates { x: 11, y: 11 }) {
             Ok(mut grid) => {
                 assert!(!grid.is_perfect_maze().unwrap());
                 AldousBroder.generate(&mut grid).expect("AldousBroder maze generation failed");

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1255,6 +1255,8 @@ mod tests {
                 // Define a helper closure to get the reverse of a given Delta move.
                 let reverse_direction = |dir: &str| -> &str {
                     match dir {
+                        "Up"       => "Up",
+                        "Down"       => "Down",
                         "Left"       => "Right",
                         "Right"      => "Left",
                         "UpperLeft"  => "LowerRight",
@@ -1361,7 +1363,6 @@ mod tests {
 
     #[test]
     fn test_make_move_delta_aldous_broder() {
-
         run_make_move_delta_test("AldousBroder");
     }
 


### PR DESCRIPTION
This fix is so user will be able to continue going a consistent direction down a corridor without needing to keep alternativing b/w opened triangle walls:
* "Left" will zigzag b/w UpperLeft, UpperRight
* "Right" will zigzag b/w UpperRight, LowerRight
* "UpperLeft" will zigzag b/w UpperLeft, Up
* "LowerLeft" will zigzag b/w LowerLeft, Down
* "UpperRight" will zigzag b/w UpperRight, Up
* "LowerRight" will zigzag b/w LowerRight, Down
* "Up" just goes Up, doesn't alternate between moves
* "Down" just goes Down, doesn't alternate between move
