### PR TITLE
0.0.10: refactor to have single Direction enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mazer"
-version = "0.0.9"
+version = "0.0.10"
 authors = ["Jeffrey Isabella <jeff.isabella@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -353,10 +353,10 @@ mod tests {
         let east = Coordinates{ x: 2, y: 1 };
         let south = Coordinates{ x: 1, y: 2 };
         let west = Coordinates{ x: 0, y: 1 };
-        neighbors.insert("North".to_string(), north.clone());
-        neighbors.insert("East".to_string(), east.clone());
-        neighbors.insert("South".to_string(), south.clone());
-        neighbors.insert("West".to_string(), west.clone());
+        neighbors.insert("Up".to_string(), north.clone());
+        neighbors.insert("Right".to_string(), east.clone());
+        neighbors.insert("Down".to_string(), south.clone());
+        neighbors.insert("Left".to_string(), west.clone());
         let mut linked: HashSet<Coordinates> = HashSet::new();
         linked.insert(north.clone());
         linked.insert(south.clone());
@@ -372,16 +372,16 @@ mod tests {
         assert!(cell2.unlinked_neighbors().contains(&east));
         assert!(cell2.unlinked_neighbors().contains(&west));
         assert!(cell2.unlinked_neighbors().len() == 2);
-        assert!(cell2.is_linked_direction(SquareDirection::North));
-        assert!(cell2.is_linked_direction(SquareDirection::South));
-        assert!(!cell2.is_linked_direction(SquareDirection::East));
-        assert!(!cell2.is_linked_direction(SquareDirection::West));
+        assert!(cell2.is_linked_direction(SquareDirection::Up));
+        assert!(cell2.is_linked_direction(SquareDirection::Down));
+        assert!(!cell2.is_linked_direction(SquareDirection::Right));
+        assert!(!cell2.is_linked_direction(SquareDirection::Left));
         assert!(cell2.is_linked(north));
         assert!(cell2.is_linked(south));
         assert!(!cell2.is_linked(east));
         assert!(!cell2.is_linked(west));
-        assert!(cell2.linked_directions().contains("North"));
-        assert!(cell2.linked_directions().contains("South"));
+        assert!(cell2.linked_directions().contains("Up"));
+        assert!(cell2.linked_directions().contains("Down"));
         assert!(cell2.linked_directions().len() == 2);
         let mut cell3 = Cell {
             neighbors_by_direction: neighbors,
@@ -395,16 +395,16 @@ mod tests {
         assert!(cell3.unlinked_neighbors().contains(&east));
         assert!(cell3.unlinked_neighbors().contains(&west));
         assert!(cell3.unlinked_neighbors().len() == 2);
-        assert!(cell3.is_linked_direction(SquareDirection::North));
-        assert!(cell3.is_linked_direction(SquareDirection::South));
-        assert!(!cell3.is_linked_direction(SquareDirection::East));
-        assert!(!cell3.is_linked_direction(SquareDirection::West));
+        assert!(cell3.is_linked_direction(SquareDirection::Up));
+        assert!(cell3.is_linked_direction(SquareDirection::Down));
+        assert!(!cell3.is_linked_direction(SquareDirection::Right));
+        assert!(!cell3.is_linked_direction(SquareDirection::Left));
         assert!(cell3.is_linked(north));
         assert!(cell3.is_linked(south));
         assert!(!cell3.is_linked(east));
         assert!(!cell3.is_linked(west));
-        assert!(cell3.linked_directions().contains("North"));
-        assert!(cell3.linked_directions().contains("South"));
+        assert!(cell3.linked_directions().contains("Up"));
+        assert!(cell3.linked_directions().contains("Down"));
         assert!(cell3.linked_directions().len() == 2);
 
     }

--- a/src/direction.rs
+++ b/src/direction.rs
@@ -13,12 +13,12 @@ pub trait Direction: Serialize {
 
 #[derive(Debug, Hash, Clone, PartialEq, Serialize, Deserialize)]
 pub enum HexDirection {
-    Northwest,
-    North,
-    Northeast,
-    Southwest,
-    South,
-    Southeast,
+    UpperLeft,
+    Up,
+    UpperRight,
+    LowerRight,
+    Down,
+    LowerLeft,
 }
 impl Direction for HexDirection {}
 
@@ -31,12 +31,12 @@ impl fmt::Display for HexDirection {
 impl From<HexDirection> for String {
     fn from(direction: HexDirection) -> Self {
         match direction {
-            HexDirection::Northwest => "Northwest".to_string(),
-            HexDirection::North => "North".to_string(),
-            HexDirection::Northeast => "Northeast".to_string(),
-            HexDirection::Southwest => "Southwest".to_string(),
-            HexDirection::South => "South".to_string(),
-            HexDirection::Southeast => "Southeast".to_string(),
+            HexDirection::UpperLeft => "UpperLeft".to_string(),
+            HexDirection::Up => "Up".to_string(),
+            HexDirection::UpperRight => "UpperRight".to_string(),
+            HexDirection::LowerRight => "LowerRight".to_string(),
+            HexDirection::Down => "Down".to_string(),
+            HexDirection::LowerLeft => "LowerLeft".to_string(),
         }
     }
 }
@@ -45,12 +45,12 @@ impl TryFrom<&str> for HexDirection {
     type Error = Error;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s {
-            "Northwest" => Ok(HexDirection::Northwest),
-            "North" => Ok(HexDirection::North),
-            "Northeast" => Ok(HexDirection::Northeast),
-            "Southwest" => Ok(HexDirection::Southwest),
-            "South" => Ok(HexDirection::South),
-            "Southeast" => Ok(HexDirection::Southeast),
+            "UpperLeft" => Ok(HexDirection::UpperLeft),
+            "Up" => Ok(HexDirection::Up),
+            "UpperRight" => Ok(HexDirection::UpperRight),
+            "LowerRight" => Ok(HexDirection::LowerRight),
+            "Down" => Ok(HexDirection::Down),
+            "LowerLeft" => Ok(HexDirection::LowerLeft),
             d => Err(Error::InvalidDirection { direction: String::from(d) }),
         }
     }
@@ -98,10 +98,10 @@ impl TryFrom<&str> for PolarDirection {
 
 #[derive(Debug, Hash, Clone, PartialEq, Serialize, Deserialize)]
 pub enum SquareDirection {
-    North,
-    East,
-    South,
-    West
+    Up,
+    Right,
+    Down,
+    Left 
 }
 
 impl Direction for SquareDirection {}
@@ -115,10 +115,10 @@ impl fmt::Display for SquareDirection {
 impl From<SquareDirection> for String {
     fn from(direction: SquareDirection) -> Self {
         match direction {
-            SquareDirection::North => "North".to_string(),
-            SquareDirection::East => "East".to_string(),
-            SquareDirection::South => "South".to_string(),
-            SquareDirection::West => "West".to_string(),
+            SquareDirection::Up => "Up".to_string(),
+            SquareDirection::Right => "Right".to_string(),
+            SquareDirection::Down => "Down".to_string(),
+            SquareDirection::Left => "Left".to_string(),
         }
     }
 }
@@ -127,10 +127,10 @@ impl TryFrom<&str> for SquareDirection {
     type Error = Error;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s {
-            "North" => Ok(SquareDirection::North),
-            "East" => Ok(SquareDirection::East),
-            "South" => Ok(SquareDirection::South),
-            "West" => Ok(SquareDirection::West),
+            "Up" => Ok(SquareDirection::Up),
+            "Right" => Ok(SquareDirection::Right),
+            "Down" => Ok(SquareDirection::Down),
+            "Left" => Ok(SquareDirection::Left),
             d => Err(Error::InvalidDirection { direction: String::from(d) }),
         }
     }

--- a/src/direction.rs
+++ b/src/direction.rs
@@ -1,184 +1,68 @@
-use serde::{ Serialize, Deserialize };
+use serde::{Serialize, Deserialize};
 use std::fmt;
-use crate::Error;
+use std::convert::TryFrom;
+use crate::cell::MazeType;
 
-pub trait Direction: Serialize { 
-    fn as_str(&self) -> String
-    where
-        Self: Into<String> + Clone,
-    {
-        self.clone().into()
-    }
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Direction {
+    // Orthogonal & intercardinal
+    Up, Right, Down, Left,
+    UpperRight, LowerRight, LowerLeft, UpperLeft,
+    // Polar‑only
+    Inward, Outward, Clockwise, CounterClockwise,
 }
 
-#[derive(Debug, Hash, Clone, PartialEq, Serialize, Deserialize)]
-pub enum HexDirection {
-    UpperLeft,
-    Up,
-    UpperRight,
-    LowerRight,
-    Down,
-    LowerLeft,
-}
-impl Direction for HexDirection {}
-
-impl fmt::Display for HexDirection {
+impl fmt::Display for Direction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_str())
+        let s = match self {
+            Direction::Up               => "Up",
+            Direction::Right            => "Right",
+            Direction::Down             => "Down",
+            Direction::Left             => "Left",
+            Direction::UpperRight       => "UpperRight",
+            Direction::LowerRight       => "LowerRight",
+            Direction::LowerLeft        => "LowerLeft",
+            Direction::UpperLeft        => "UpperLeft",
+            Direction::Inward           => "Inward",
+            Direction::Outward          => "Outward",
+            Direction::Clockwise        => "Clockwise",
+            Direction::CounterClockwise => "CounterClockwise",
+        };
+        write!(f, "{}", s)
     }
 }
 
-impl From<HexDirection> for String {
-    fn from(direction: HexDirection) -> Self {
-        match direction {
-            HexDirection::UpperLeft => "UpperLeft".to_string(),
-            HexDirection::Up => "Up".to_string(),
-            HexDirection::UpperRight => "UpperRight".to_string(),
-            HexDirection::LowerRight => "LowerRight".to_string(),
-            HexDirection::Down => "Down".to_string(),
-            HexDirection::LowerLeft => "LowerLeft".to_string(),
-        }
-    }
-}
-
-impl TryFrom<&str> for HexDirection {
-    type Error = Error;
+impl TryFrom<&str> for Direction {
+    type Error = crate::Error;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        match s {
-            "UpperLeft" => Ok(HexDirection::UpperLeft),
-            "Up" => Ok(HexDirection::Up),
-            "UpperRight" => Ok(HexDirection::UpperRight),
-            "LowerRight" => Ok(HexDirection::LowerRight),
-            "Down" => Ok(HexDirection::Down),
-            "LowerLeft" => Ok(HexDirection::LowerLeft),
-            d => Err(Error::InvalidDirection { direction: String::from(d) }),
-        }
+        Ok(match s {
+            "Up"               => Direction::Up,
+            "Right"            => Direction::Right,
+            "Down"             => Direction::Down,
+            "Left"             => Direction::Left,
+            "UpperRight"       => Direction::UpperRight,
+            "LowerRight"       => Direction::LowerRight,
+            "LowerLeft"        => Direction::LowerLeft,
+            "UpperLeft"        => Direction::UpperLeft,
+            "Inward"           => Direction::Inward,
+            "Outward"          => Direction::Outward,
+            "Clockwise"        => Direction::Clockwise,
+            "CounterClockwise" => Direction::CounterClockwise,
+            other =>
+                return Err(crate::Error::InvalidDirection { direction: other.to_string() }),
+        })
     }
 }
 
-#[derive(Debug, Hash, Clone, PartialEq, Serialize, Deserialize)]
-pub enum PolarDirection {
-    Clockwise,
-    CounterClockwise,
-    Inward,
-    Outward,
-}
-
-impl Direction for PolarDirection {}
-
-impl fmt::Display for PolarDirection {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-impl From<PolarDirection> for String {
-    fn from(direction: PolarDirection) -> Self {
-        match direction {
-            PolarDirection::Clockwise => "Clockwise".to_string(),
-            PolarDirection::CounterClockwise => "CounterClockwise".to_string(),
-            PolarDirection::Inward => "Inward".to_string(),
-            PolarDirection::Outward => "Outward".to_string(),
-        }
-    }
-}
-
-impl TryFrom<&str> for PolarDirection {
-    type Error = Error;
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        match s {
-            "Clockwise" => Ok(PolarDirection::Clockwise),
-            "CounterClockwise" => Ok(PolarDirection::CounterClockwise),
-            "Inward" => Ok(PolarDirection::Inward),
-            "Outward" => Ok(PolarDirection::Outward),
-            d => Err(Error::InvalidDirection { direction: String::from(d) }),
-        }
-    }
-}
-
-#[derive(Debug, Hash, Clone, PartialEq, Serialize, Deserialize)]
-pub enum SquareDirection {
-    Up,
-    Right,
-    Down,
-    Left 
-}
-
-impl Direction for SquareDirection {}
-
-impl fmt::Display for SquareDirection {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-impl From<SquareDirection> for String {
-    fn from(direction: SquareDirection) -> Self {
-        match direction {
-            SquareDirection::Up => "Up".to_string(),
-            SquareDirection::Right => "Right".to_string(),
-            SquareDirection::Down => "Down".to_string(),
-            SquareDirection::Left => "Left".to_string(),
-        }
-    }
-}
-
-impl TryFrom<&str> for SquareDirection {
-    type Error = Error;
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        match s {
-            "Up" => Ok(SquareDirection::Up),
-            "Right" => Ok(SquareDirection::Right),
-            "Down" => Ok(SquareDirection::Down),
-            "Left" => Ok(SquareDirection::Left),
-            d => Err(Error::InvalidDirection { direction: String::from(d) }),
-        }
-    }
-}
-
-
-#[derive(Debug, Hash, Clone, PartialEq, Serialize, Deserialize)]
-pub enum TriangleDirection {
-    UpperLeft,
-    UpperRight,
-    Down,
-    Up,
-    LowerLeft,
-    LowerRight,
-}
-
-impl Direction for TriangleDirection {}
-
-impl fmt::Display for TriangleDirection {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-impl From<TriangleDirection> for String {
-    fn from(direction: TriangleDirection) -> Self {
-        match direction {
-            TriangleDirection::UpperLeft => "UpperLeft".to_string(),
-            TriangleDirection::UpperRight => "UpperRight".to_string(),
-            TriangleDirection::Down => "Down".to_string(),
-            TriangleDirection::Up => "Up".to_string(),
-            TriangleDirection::LowerLeft => "LowerLeft".to_string(),
-            TriangleDirection::LowerRight => "LowerRight".to_string(),
-        }
-    }
-}
-
-impl TryFrom<&str> for TriangleDirection {
-    type Error = Error;
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        match s {
-            "UpperLeft" => Ok(TriangleDirection::UpperLeft),
-            "UpperRight" => Ok(TriangleDirection::UpperRight),
-            "Down" => Ok(TriangleDirection::Down),
-            "Up" => Ok(TriangleDirection::Up),
-            "LowerLeft" => Ok(TriangleDirection::LowerLeft),
-            "LowerRight" => Ok(TriangleDirection::LowerRight),
-            d => Err(Error::InvalidDirection { direction: String::from(d) }),
+impl Direction {
+    /// “Which of these variants are legal for a given MazeType?”
+    pub fn valid_for(&self, maze_type: MazeType) -> bool {
+        use Direction::*;
+        match maze_type {
+            MazeType::Orthogonal => matches!(self, Up | Right | Down | Left),
+            MazeType::Sigma      => matches!(self, Up | Right | Down | Left | UpperRight | LowerRight | LowerLeft | UpperLeft),
+            MazeType::Delta      => matches!(self, Up | Down | UpperLeft | UpperRight | LowerLeft | LowerRight),
+            MazeType::Polar      => matches!(self, Inward | Outward | Clockwise | CounterClockwise),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,8 @@
-use crate::cell::{ Coordinates, MazeType };
-use crate::algorithms::MazeAlgorithm;
 use std::fmt;
 use serde_json;
+use crate::cell::{ Coordinates, MazeType };
+use crate::direction::Direction;
+use crate::algorithms::MazeAlgorithm;
 
 #[derive(Debug)]
 pub enum Error {
@@ -15,7 +16,7 @@ pub enum Error {
     MultipleActiveCells { count: usize },
     NoActiveCells,
     InvalidDirection { direction: String },
-    MoveUnavailable { attempted_move: String, available_moves: Vec<String>},
+    MoveUnavailable { attempted_move: Direction, available_moves: Vec<Direction>},
     SerializationError(serde_json::Error),
     EmptyList,
 }
@@ -51,7 +52,7 @@ impl fmt::Display for Error {
                 write!(f, "No active cells, there should always be exactly 1 active cell" )
             }
             Error::MoveUnavailable { attempted_move, available_moves } => {
-                write!(f, "Cannot make move {:?} because it is unavailable. Available moves are: {:?}", attempted_move, available_moves.join(", ") )
+                write!(f, "Cannot make move {:?} because it is unavailable. Available moves are: {:?}", attempted_move, available_moves.into_iter().map(|dir| dir.to_string()).collect::<Vec<_>>().join(", ") )
             }
             Error::InvalidDirection { direction } => {
                 write!(f, "Invalid Direction: {:?}", direction )

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -315,7 +315,6 @@ pub extern "C" fn mazer_ffi_integration_test() -> i32 {
 mod tests {
     use super::*;
     use std::collections::{HashSet, HashMap};
-    use crate::behaviors::collections::SetDifference;
     use crate::cell::{CellOrientation, MazeType, Cell, Coordinates};
    
     #[test]

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -3,6 +3,8 @@ use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_void};
 use crate::grid::Grid;
 use crate::cell::Cell;
+use crate::direction::Direction;
+
 
 /// Representation of a cell for the FFI layer.
 ///
@@ -64,7 +66,7 @@ impl From<&Cell> for FFICell {
         let open_walls_raw: Vec<*const c_char> = cell.open_walls.iter()
             .map(|direction| {
                 // Convert each Rust string into a raw C string.
-                CString::new(direction.clone())
+                CString::new(direction.to_string().clone())
                     .unwrap()
                     .into_raw() as *const c_char
             })
@@ -285,8 +287,13 @@ pub extern "C" fn mazer_make_move(grid_ptr: *mut c_void, direction: *const c_cha
         }
     };
 
+    let dir = match Direction::try_from(direction_str) {
+        Ok(d)   => d,
+        Err(_)  => return ptr::null_mut(),
+    };
+
     // Call the make_move method on the mutable grid.
-    let _ = grid.make_move(direction_str);
+    let _ = grid.make_move(dir);
 
     // Return the same pointer to the grid.
     grid_ptr
@@ -313,19 +320,19 @@ mod tests {
    
     #[test]
     fn test_memory_allocation_for_ffi_cell() {
-        let mut neighbors: HashMap<String, Coordinates> = HashMap::new();
-        neighbors.insert("North".to_string(), Coordinates { x: 1, y: 1 });
-        neighbors.insert("East".to_string(), Coordinates { x: 2, y: 2 });
-        neighbors.insert("South".to_string(), Coordinates { x: 1, y: 3 });
-        neighbors.insert("West".to_string(), Coordinates { x: 0, y: 2 });
+        let mut neighbors: HashMap<Direction, Coordinates> = HashMap::new();
+        neighbors.insert(Direction::Up, Coordinates { x: 1, y: 1 });
+        neighbors.insert(Direction::Right, Coordinates { x: 2, y: 2 });
+        neighbors.insert(Direction::Down, Coordinates { x: 1, y: 3 });
+        neighbors.insert(Direction::Left, Coordinates { x: 0, y: 2 });
 
         let mut linked: HashSet<Coordinates> = HashSet::new();
         linked.insert(Coordinates { x: 2, y: 2 });
         linked.insert(Coordinates { x: 1, y: 3 });
 
-        let mut open_walls: Vec<String> = Vec::new();
-        open_walls.push(String::from("East"));
-        open_walls.push(String::from("South"));
+        let mut open_walls: Vec<Direction> = Vec::new();
+        open_walls.push(Direction::Right);
+        open_walls.push(Direction::Down);
 
         let cell = Cell {
             coords: Coordinates { x: 1, y: 2 },
@@ -367,7 +374,7 @@ mod tests {
             .iter()
             .filter_map(|(k, &v)| {
                 if cell.linked.contains(&v) {
-                    Some(k.clone())
+                    Some(k.to_string().clone())
                 } else {
                     None
                 }
@@ -496,7 +503,7 @@ mod tests {
                 let grid_ptr: *mut c_void = Box::into_raw(boxed_grid) as *mut c_void;
 
                 // Create a CString for the direction.
-                let direction = CString::new("North").expect("CString::new failed");
+                let direction = CString::new("Up").expect("CString::new failed");
 
                 // Call the FFI function within an unsafe block.
                 let updated_ptr = mazer_make_move(grid_ptr, direction.as_ptr());
@@ -524,38 +531,43 @@ mod tests {
                 
                 // Limit the borrow's scope and return only owned data.
                 let (original_coords, available_moves, unavailable_moves) = {
-                    if let Ok(active_cell) = maze.get_active_cell() {
-                        // Clone the data so we own it.
-                        let original_coords = active_cell.coords.clone();
-                        // Clone available moves to a Vec<String>.
-                        let available_moves: Vec<String> = active_cell.open_walls.clone();
-                        // Create a vector of &str from the owned Strings,
-                        // which we then use to compute diff.
-                        let available_refs: Vec<&str> = available_moves.iter().map(|s| s.as_str()).collect();
-                        // Use your diff helper to get the unavailable moves.
-                        // Then convert those to owned Strings so that they don't borrow available_moves.
-                        let unavailable_moves: Vec<String> = ["North", "East", "South", "West"].diff(&available_refs)
-                            .into_iter()
-                            .map(|s| s.to_string())
-                            .collect();
-
-                        (original_coords, available_moves, unavailable_moves)
-                    } else {
-                        panic!("Expected an active cell at the start");
-                    }
-                }; // All borrows are dropped here.
+                    // 1) Grab the active cell or panic
+                    let active = maze
+                        .get_active_cell()
+                        .expect("Expected an active cell at the start");
+                
+                    // 2) Clone its coords
+                    let original_coords = active.coords.clone();
+                
+                    // 3) Collect its open_walls directly as a Vec<Direction>
+                    //    (assuming open_walls: HashSet<Direction> or Vec<Direction>)
+                    let available_moves: Vec<Direction> = active.open_walls.iter().cloned().collect();
+                
+                    // 4) Anything in `all_moves` not in `available_moves` is “unavailable”
+                    let unavailable_moves: Vec<Direction> = maze.all_moves()
+                        .iter()
+                        .filter(|d| !available_moves.contains(d))
+                        .cloned()
+                        .collect();
+                
+                    (original_coords, available_moves, unavailable_moves)
+                }; // all borrows dropped here
 
                 // Now it's safe to perform mutable operations.
 
                 // Try a move that is unavailable using a copied maze.
                 let mut copied_maze = maze.clone();
+
+                let bad_move = unavailable_moves
+                    .first()
+                    .expect("Expected at least 1 unavailable move");
+
                 assert!(
-                    copied_maze
-                        .make_move(unavailable_moves.iter().next().unwrap())
-                        .is_err(),
-                    "Should not allow an unavailable move"
+                    copied_maze.make_move(*bad_move).is_err(),
+                    "Should not allow unavailable move {}",
+                    bad_move
                 );
-                
+
                 assert_eq!(
                     copied_maze.cells.iter().filter(|cell| cell.is_visited).count(),
                     1,
@@ -569,13 +581,8 @@ mod tests {
                 );
                 
                 // Try a valid move on the original maze.
-                assert!(
-                    maze
-                        .make_move(available_moves.iter().next().unwrap().as_str())
-                        .is_ok(),
-                    "Should allow a valid move"
-                );
-                
+                let next = available_moves.first().expect("There should be available moves"); 
+                assert!(maze.make_move(*next).is_ok(), "Should allow a valid move");
 
                 // Verify that exactly one cell is active.
                 assert_eq!(

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -772,8 +772,6 @@ impl Grid {
 mod tests {
     use super::*;
 
-    use crate::behaviors::collections::SetDifference;
-
     #[test]
     fn init_orthogonal_grid() {
         match Grid::new(MazeType::Orthogonal, 4, 4, Coordinates{x:0, y:0}, Coordinates{x:3, y:3}) {
@@ -1055,11 +1053,11 @@ mod tests {
         // pull out start‐cell info
         let (original_coords, available_moves, unavailable_moves) = {
             // 1) Temporarily borrow mutably just to pull out coords, open_walls, and maze_type
-            let (orig, open_walls, maze_type) = {
+            let (orig, open_walls) = {
                 let c = maze
                     .get_active_cell()
                     .expect("Expected start cell");
-                (c.coords.clone(), c.open_walls.clone(), maze.maze_type)
+                (c.coords.clone(), c.open_walls.clone())
             }; // ← `c` (and its &mut borrow) drops here
         
             // 2) available_moves is just the cloned open_walls
@@ -1260,7 +1258,7 @@ mod tests {
                 .cloned()
             {
                 // 2c) make the second forward move
-                let actual2 = maze
+                let _ = maze
                     .make_move(requested2)
                     .expect("Second valid move should succeed");
                 let cell_after_second = maze.get_active_cell().unwrap().coords.clone();

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -421,25 +421,25 @@ impl Grid {
 
                 if cell.y() != 0 {
                     neighbors.insert(
-                        SquareDirection::North.to_string(), 
+                        SquareDirection::Up.to_string(), 
                         self.get_by_coords(cell.x(), cell.y() - 1)?.coords
                     );
                 }
                 if cell.x() < self.width - 1 {
                     neighbors.insert(
-                        SquareDirection::East.to_string(), 
+                        SquareDirection::Right.to_string(), 
                         self.get_by_coords(cell.x() + 1, cell.y())?.coords
                     );
                 }
                 if cell.y() < self.height - 1 {
                     neighbors.insert(
-                        SquareDirection::South.to_string(), 
+                        SquareDirection::Down.to_string(), 
                         self.get_by_coords(cell.x(), cell.y() + 1)?.coords
                     );
                 }
                 if cell.x() != 0 {
                     neighbors.insert(
-                        SquareDirection::West.to_string(), 
+                        SquareDirection::Left.to_string(), 
                         self.get_by_coords(cell.x() - 1, cell.y())?.coords
                     );
                 }
@@ -520,37 +520,37 @@ impl Grid {
                 };
                 if col > 0 && north_diagonal < self.height {
                     neighbors.insert(
-                        HexDirection::Northwest.to_string(),
+                        HexDirection::UpperLeft.to_string(),
                         self.get_by_coords(col - 1, north_diagonal)?.coords,
                     );
                 }
                 if col < self.width && row > 0 {
                     neighbors.insert(
-                        HexDirection::North.to_string(),
+                        HexDirection::Up.to_string(),
                         self.get_by_coords(col, row - 1)?.coords,
                     );
                 }
                 if col < self.width - 1 && north_diagonal < self.height {
                     neighbors.insert(
-                        HexDirection::Northeast.to_string(),
+                        HexDirection::UpperRight.to_string(),
                         self.get_by_coords(col + 1, north_diagonal)?.coords,
                     );
                 }
                 if col > 0 && south_diagonal < self.height {
                     neighbors.insert(
-                        HexDirection::Southwest.to_string(),
+                        HexDirection::LowerLeft.to_string(),
                         self.get_by_coords(col - 1, south_diagonal)?.coords,
                     );
                 }
                 if row < self.height - 1 && col < self.width {
                     neighbors.insert(
-                        HexDirection::South.to_string(),
+                        HexDirection::Down.to_string(),
                         self.get_by_coords(col, row + 1)?.coords,
                     );
                 }
                 if col < self.width - 1 && south_diagonal < self.height {
                     neighbors.insert(
-                        HexDirection::Southeast.to_string(),
+                        HexDirection::LowerRight.to_string(),
                         self.get_by_coords(col + 1, south_diagonal)?.coords,
                     );
                 }
@@ -731,14 +731,14 @@ impl Grid {
             let mut bottom = String::from("+");
             for cell in row {
                 let body = "   ";
-                let east_boundary = match cell.neighbors_by_direction.get(&SquareDirection::East.to_string()).is_some() {
-                    true if cell.is_linked_direction(SquareDirection::East) => " ",
+                let east_boundary = match cell.neighbors_by_direction.get(&SquareDirection::Right.to_string()).is_some() {
+                    true if cell.is_linked_direction(SquareDirection::Right) => " ",
                     _ => "|",
                 };
                 top.push_str(body);
                 top.push_str(east_boundary);
-                let south_boundary = match cell.neighbors_by_direction.get(&SquareDirection::South.to_string()).is_some() {
-                    true if cell.is_linked_direction(SquareDirection::South) => "   ",
+                let south_boundary = match cell.neighbors_by_direction.get(&SquareDirection::Down.to_string()).is_some() {
+                    true if cell.is_linked_direction(SquareDirection::Down) => "   ",
                     _ => "---"
                 };
                 let corner ="+";
@@ -1045,7 +1045,7 @@ mod tests {
             let orig = c.coords.clone();
             let available: Vec<String> = c.open_walls.clone();
             let available_refs: Vec<&str> = available.iter().map(String::as_str).collect();
-            let unavailable: Vec<String> = ["North", "East", "South", "West"]
+            let unavailable: Vec<String> = ["Up", "Right", "Down", "Left"]
                 .diff(&available_refs)
                 .into_iter()
                 .map(str::to_string)
@@ -1101,10 +1101,10 @@ mod tests {
         // helper to reverse orthogonal directions
         let reverse_direction = |dir: &str| -> &str {
             match dir {
-                "North" => "South",
-                "South" => "North",
-                "East"  => "West",
-                "West"  => "East",
+                "Up" => "Down",
+                "Down" => "Up",
+                "Right"  => "Left",
+                "Left"  => "Right",
                 other   => panic!("Unknown direction: {}", other),
             }
         };
@@ -1266,10 +1266,9 @@ mod tests {
                 let cell_after_back_to_start = maze.get_active_cell().unwrap().coords.clone();
                 assert_eq!(cell_after_back_to_start, original_coords);
     
-                // 4c) no further backtracking allowed
                 assert!(
-                    maze.make_move(&back1_again).is_err(),
-                    "Further backtracking from start should fail"
+                    maze.get(maze.start_coords).expect("error getting start coords").is_visited == true,
+                    "Start cell should remain visited"
                 );
             } else {
                 println!("Not enough available moves for a second forward move; skipping Delta backtracking tests.");


### PR DESCRIPTION
also, Delta maze moves Up and Down attempt upward/downward moves (e.g. UpperLeft, UpperRight as fail back moves for Up, similar downward behavior for Down). Previously, Up only tried Up and Down only tried Down
