### PR TITLE
updated FFI make move to return null ptr on unsuccessful move

### DIFF
--- a/include/mazer.h
+++ b/include/mazer.h
@@ -86,7 +86,7 @@ void mazer_free_cells(FFICell *ptr, size_t length);
  *
  * @param grid_ptr A pointer to the mutable Grid.
  * @param direction A null-terminated C string indicating the move direction.
- * @return A pointer to the updated Grid.
+ * @return A pointer to the updated `Grid` instance if successful, or a null pointer if an error occurs.
  */
 void* mazer_make_move(void* grid_ptr, const char* direction);
 


### PR DESCRIPTION
this will allow Swift side to easily display sounds ONLY when move is made
